### PR TITLE
Fix bug: choosing effective group for current user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ local_api: $(SRC)
 install: local_api
 	mkdir -p $(DESTDIR)$(CONFIG)/next-prayer
 	cp -iv config.json $(DESTDIR)$(CONFIG)/next-prayer/config.json
-	chown -R "$(LGUSER):$(LGUSER)" $(DESTDIR)$(CONFIG)/next-prayer
+	chown -R "$(LGUSER):$(LGGROUP)" $(DESTDIR)$(CONFIG)/next-prayer
 	chmod 754 $(DESTDIR)$(CONFIG)/next-prayer
 	chmod 644 $(DESTDIR)$(CONFIG)/next-prayer/config.json
 	mkdir -p $(DESTDIR)$(LPREFIX)/share/next-prayer/calendar/{2021..2026}/{1..12}
@@ -22,14 +22,14 @@ install: local_api
 	python3 remote_api.py
 	sed -i "s|^config_file.*|config_file = \"$(CONFIG)/next-prayer/config.json\"|g" remote_api.py
 	sed -i "s|^data_path.*|data_path = \"$(LPREFIX)/share/next-prayer/calendar\"|g" remote_api.py
-	chown -R "$(LGUSER):$(LGUSER)" $(DESTDIR)$(LPREFIX)/share/next-prayer
+	chown -R "$(LGUSER):$(LGGROUP)" $(DESTDIR)$(LPREFIX)/share/next-prayer
 	chmod -R 754 $(DESTDIR)$(LPREFIX)/share/next-prayer
 	mkdir -p $(DESTDIR)$(LPREFIX)/bin
 	cp -f local_api $(DESTDIR)$(LPREFIX)/bin
 	cp -f remote_api.py $(DESTDIR)$(LPREFIX)/bin
 	cp -f next-prayer $(DESTDIR)$(LPREFIX)/bin
 	chmod 755 $(DESTDIR)$(LPREFIX)/bin/local_api
-	chown "$(LGUSER):$(LGUSER)" $(DESTDIR)$(LPREFIX)/bin/remote_api.py
+	chown "$(LGUSER):$(LGGROUP)" $(DESTDIR)$(LPREFIX)/bin/remote_api.py
 	chmod 755 $(DESTDIR)$(LPREFIX)/bin/next-prayer
 	sed "s/VERSION/$(VERSION)/g" < next-prayer > $(DESTDIR)$(LPREFIX)/bin/next-prayer
 	mkdir -p $(DESTDIR)$(MAN)/man1

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Islamic prayers reminder for status bars.
 
 ```
 -n, --next     		The next prayer and its time.
--p, --previous 		The previous prayer and its time.
+-p, --prev  		The previous prayer and its time.
 -i, --hybrid  		Display the elapsed time since the previous prayer until the elapsed time reach threshold time determined in config file, Then it will display the next prayer and its time.
 -e, --elapsed  		The elapsed time since the previous prayer.
 -l, --left    		The time left until the next prayer.

--- a/config.mk
+++ b/config.mk
@@ -13,6 +13,7 @@ MAN = $(LPREFIX)/man
 DOC = $(SPREFIX)/doc
 LIC = $(SPREFIX)/licenses
 LGUSER = $(shell users | awk '{ print $$1 }')
+LGGROUP = $(shell id -gn')
 CONFIG = /home/$(LGUSER)/.config
 
 # C++ flags

--- a/config.mk
+++ b/config.mk
@@ -13,7 +13,7 @@ MAN = $(LPREFIX)/man
 DOC = $(SPREFIX)/doc
 LIC = $(SPREFIX)/licenses
 LGUSER = $(shell users | awk '{ print $$1 }')
-LGGROUP = $(shell id -gn')
+LGGROUP = $(shell id -gn $(LGUSER))
 CONFIG = /home/$(LGUSER)/.config
 
 # C++ flags

--- a/next-prayer
+++ b/next-prayer
@@ -100,7 +100,7 @@ hybrid() {
 [[ ${adhan_time} == "yes" ]] && notify-send -t 60000 "Next Prayer" "NOW It's the time for ${next_prayer}"
 
 case "$1" in
-	"--prev"|"-p") echo "🕌 ${prev_prayer} $(format ${prev_prayer_time})" ;;
+	"--previous"|"-p") echo "🕌 ${prev_prayer} $(format ${prev_prayer_time})" ;;
 	"--left"|"-l") echo "${time_left} until ${next_prayer}" ;;
 	"--elapsed"|"-e") echo "${elapsed_time} since ${prev_prayer}" ;;
 	"--adhan"|"-a") echo "${adhan_time}" ;;

--- a/next-prayer
+++ b/next-prayer
@@ -55,7 +55,7 @@ info() {
 	printf "%s\n%s\t\t%s\n%s\t\t%s\n%s\t\t%s\n%s\t\t%s\n%s\t\t%s\n%s\t\t%s\n%s\t\t%s\n%s\t\t%s\n" \
 		"Flags:" \
 		"-n, --next"     		"The next prayer and its time." \
-		"-p, --previous" 		"The previous prayer and its time." \
+		"-p, --prev"    		"The previous prayer and its time." \
 		"-i, --hybrid"  		"Display the elapsed time since the previous prayer until the elapsed time reach threshold time determined in config file, Then it will display the next prayer and its time." \
 		"-e, --elapsed"  		"The elapsed time since the previous prayer." \
 		"-l, --left"    		"The time left until the next prayer." \
@@ -100,7 +100,7 @@ hybrid() {
 [[ ${adhan_time} == "yes" ]] && notify-send -t 60000 "Next Prayer" "NOW It's the time for ${next_prayer}"
 
 case "$1" in
-	"--previous"|"-p") echo "🕌 ${prev_prayer} $(format ${prev_prayer_time})" ;;
+	"--prev"|"-p") echo "🕌 ${prev_prayer} $(format ${prev_prayer_time})" ;;
 	"--left"|"-l") echo "${time_left} until ${next_prayer}" ;;
 	"--elapsed"|"-e") echo "${elapsed_time} since ${prev_prayer}" ;;
 	"--adhan"|"-a") echo "${adhan_time}" ;;


### PR DESCRIPTION
Bug 1: `--previous` flag was written as `--prev` in the actual code which lead to an improper behavior in the main functionality of the program.
Bug 2: Error while running `make` due to group permission misconfiguration. (Tested on Archlinux, Debian VM and Google Cloud Shell) 